### PR TITLE
also index private messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ssb-backlinks
 
-[scuttlebot](http://scuttlebutt.nz/) plugin for indexing all link mentions of messages.
+[scuttlebot](http://scuttlebutt.nz/) plugin for indexing all link mentions of messages (including private for the current identity).
 
 Walks all values of a message searching for [ssb-ref](https://github.com/ssbc/ssb-ref) recognized keys. Provides an [ssb-query](https://github.com/dominictarr/ssb-query) style interface.
 

--- a/lib/flumeview-links-raw.js
+++ b/lib/flumeview-links-raw.js
@@ -1,4 +1,5 @@
 // FORKED TO REMOVE FILTERING APPLIED TO INDEXED DATA RESULT
+// AND ADD unbox OPTION
 
 'use strict'
 var pull = require('pull-stream')
@@ -11,11 +12,7 @@ var FlumeViewLevel = require('flumeview-level')
 
 var isArray = Array.isArray
 
-//sorted index.
-
-//split this into TWO modules. flumeview-links and flumeview-query
-module.exports = function (indexes, links, version) {
-
+module.exports = function (indexes, links, version, unbox) {
   if(!links)
     links = function (data, emit) { emit(data) }
 
@@ -34,16 +31,18 @@ module.exports = function (indexes, links, version) {
     return A
   }
 
-  var create = FlumeViewLevel(version || 1, function (value, seq) {
-    var A = []
-    links(value, function (value) {
-      A = A.concat(getIndexes(value, seq))
+  var create = FlumeViewLevel(version || 1, function (msg, seq) {
+    var result = []
+    if (typeof msg.value.content === 'string' && unbox) {
+      msg = unbox(msg)
+    }
+    links(msg, function (value) {
+      result = result.concat(getIndexes(value, seq))
     })
-    return A
+    return result
   })
 
   return function (log, name) {
-
     var index = create(log, name)
     var read = index.read
 
@@ -84,7 +83,6 @@ module.exports = function (indexes, links, version) {
         )
       var _opts = query(index, q)
 
-
       _opts.values = false
       _opts.keys = true
 
@@ -97,11 +95,15 @@ module.exports = function (indexes, links, version) {
       return pull(
         read(_opts),
         pull.map(function (data) {
-          if(data.sync) return data
-          var o = data.value
-          for(var i = 0; i < index.value.length; i++)
-            u.set(index.value[i], data.key[i+1], o)
-          return o
+          if (data.sync) return data
+          var msg = data.value
+          if (typeof msg.value.content === 'string' && unbox) {
+            msg = unbox(msg)
+          }
+          for (var i = 0; i < index.value.length; i++) {
+            u.set(index.value[i], data.key[i + 1], msg)
+          }
+          return msg
         }),
         isArray(opts.query) ? mfr(opts.query) : pull.through()
       )

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "url": "git://github.com/ssbc/ssb-backlinks.git"
   },
   "dependencies": {
+    "base64-url": "^1.3.3",
     "deep-equal": "^1.0.1",
     "flumeview-level": "^2.0.3",
     "flumeview-query": "^3.0.3",
     "map-filter-reduce": "^3.0.3",
     "pull-flatmap": "0.0.1",
     "pull-stream": "^3.6.0",
+    "ssb-keys": "^7.0.9",
     "ssb-ref": "^2.7.1",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
Because patchcore uses ssb-backlinks for getting likes, we're not seeing private likes.

**This PR adds automatic unboxing to the ssb-backlinks index so that all links including private messages are now correctly indexed.**

How do folks feel about this? @clehner @dominictarr @ahdinosaur @mixmix 

Is there a better place we could handle this further up the stack?