### PR TITLE
Add tests for emit-links and swap out unneeded deps

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test/
+.github/

--- a/emit-links.js
+++ b/emit-links.js
@@ -1,6 +1,4 @@
 var ref = require('ssb-ref')
-var deepEqual = require('deep-equal')
-var extend = require('xtend')
 var matchChannel = /^#[^\s#]+$/
 
 module.exports = emitLinks
@@ -9,7 +7,7 @@ function emitLinks (msg, emit) {
   var links = new Set()
   walk(msg.value.content, function (path, value) {
     // HACK: handle legacy channel mentions
-    if (deepEqual(path, ['channel'])) {
+    if (Array.isArray(path) && path[0] === 'channel') {
       var channel = ref.normalizeChannel(value)
       if (channel) {
         value = `#${channel}`
@@ -24,7 +22,7 @@ function emitLinks (msg, emit) {
     }
   })
   links.forEach(link => {
-    emit(extend(msg, {
+    emit(Object.assign(msg, {
       rts: resolveTimestamp(msg),
       dest: link
     }))

--- a/emit-links.js
+++ b/emit-links.js
@@ -22,7 +22,7 @@ function emitLinks (msg, emit) {
     }
   })
   links.forEach(link => {
-    emit(Object.assign(msg, {
+    emit(Object.assign({}, msg, {
       rts: resolveTimestamp(msg),
       dest: link
     }))

--- a/package.json
+++ b/package.json
@@ -9,15 +9,18 @@
   },
   "dependencies": {
     "base64-url": "^2.2.0",
-    "deep-equal": "^1.0.1",
     "flumeview-query": "^6.2.0",
     "pull-stream": "^3.6.7",
     "ssb-keys": "^7.0.14",
-    "ssb-ref": "^2.9.0",
-    "xtend": "^4.0.1"
+    "ssb-ref": "^2.9.0"
   },
-  "devDependencies": {},
-  "scripts": {},
+  "devDependencies": {
+    "ava": "^0.25.0",
+    "sinon": "^7.1.1"
+  },
+  "scripts": {
+    "test": "ava"
+  },
   "author": "Secure Scuttlebutt Consortium",
   "license": "MIT"
 }

--- a/test/emit-links.test.js
+++ b/test/emit-links.test.js
@@ -1,0 +1,60 @@
+const test = require('ava')
+const sinon = require('sinon')
+const ref = require('ssb-ref')
+const emitLinks = require('../emit-links')
+
+let emit = sinon.stub()
+
+test.before(() => {
+  sinon.stub(ref, 'normalizeChannel')
+  sinon.stub(ref, 'type')
+})
+
+test.afterEach(() => {
+  ref.normalizeChannel.reset()
+  ref.type.reset()
+  emit.reset()
+})
+
+test.after.always(() => {
+  ref.normalizeChannel.restore()
+  ref.type.restore()
+})
+
+test('emitLinks does not call emit fn if there are no links', (t) => {
+  const msg = { value: { content: {} } }
+  emitLinks(msg, emit)
+  t.true(emit.notCalled)
+})
+
+test('emitLinks calls emit fn if links are found in content', (t) => {
+  const msg = { value: { content: { contact: 'contact-id' } } }
+  ref.type.returns(true)
+  emitLinks(msg, emit)
+  t.true(emit.calledOnce)
+})
+
+test('emitLinks does not call emit fn for duplicate links', (t) => {
+  const msg = { value: { content: { contact: 'contact-id', contact2: 'contact-id' } } }
+  ref.type.returns(true)
+  emitLinks(msg, emit)
+  t.true(emit.calledOnce)
+})
+
+test('emitLinks should normalize the link if it is a channel', (t) => {
+  const msg = { value: { content: { channel: 'channel-name' } } }
+  ref.normalizeChannel.returnsArg(0)
+  emitLinks(msg, emit)
+  t.true(ref.normalizeChannel.firstCall.calledWith('channel-name'))
+  t.true(emit.calledOnce)
+})
+
+test('emitLinks should call emit fn with added rts and dest fields', (t) => {
+  const msg = { value: { content: { contact: 'contact-id' }, timestamp: 1 } }
+  ref.type.returns(true)
+  emitLinks(msg, emit)
+  t.true(emit.calledWith(Object.assign(msg, {
+    rts: 1,
+    dest: 'contact-id'
+  })))
+})

--- a/test/emit-links.test.js
+++ b/test/emit-links.test.js
@@ -53,7 +53,7 @@ test('emitLinks should call emit fn with added rts and dest fields', (t) => {
   const msg = { value: { content: { contact: 'contact-id' }, timestamp: 1 } }
   ref.type.returns(true)
   emitLinks(msg, emit)
-  t.true(emit.calledWith(Object.assign(msg, {
+  t.true(emit.calledWith(Object.assign({}, msg, {
     rts: 1,
     dest: 'contact-id'
   })))


### PR DESCRIPTION
Closes #10 

I added some tests before swapping out xtend for Object.assign (and a simple array check for deepEquals) to make sure that I didn't accidentally break anything.