### PR TITLE
Documentation Drive: added plugin usage details and link to secret-stack plugin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,37 @@ pull(
 )
 ```
 
+## Example usage as a Secret-Stack Plugin
+`ssb-backlinks` can also be used as a `secret-stack`
+[plugin](https://github.com/ssbc/secret-stack/blob/master/plugins.md) directly.
+
+```js
+var SecretStack = require('secret-stack')
+var config = require('./some-config-file')
+
+var {pull, drain} = require('pull-stream')
+
+// you'd need many more plugins to make this useful
+// demo purposes only
+var create = SecretStack({
+  appKey: appKey //32 random bytes
+})
+.use(require('ssb-db'))
+.use(require('ssb-backlinks'))
+.use(function (sbot, config) {
+  pull(
+    sbot.backlink.read({
+      query: [{$filter: {dest: "%dfadf..."}}], // some message hash
+      index: 'DTA',
+      live: true
+    }),
+    drain(console.log)
+  )
+)}
+
+var server = create(config) // start application
+```
+
 ## Versions
 
 Please note that 0.7.0 requires scuttlebot 11.3


### PR DESCRIPTION
This add plugin usage documenation and a link to the `secret-stack` plugin docs.

reference: #13 