### PR TITLE
Revert indexVersion to avoid full rebuilds

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var indexes = [
   { key: 'TDT', value: [['value', 'content', 'type'], ['dest'], ['rts']] }
 ]
 
-var indexVersion = 9
+var indexVersion = 8
 
 exports.name = 'backlinks'
 exports.version = require('./package.json').version

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssb-backlinks",
   "description": "scuttlebot plugin for indexing all link mentions of messages",
-  "version": "1.0.0",
+  "version": "0.8.0",
   "homepage": "https://github.com/ssbc/ssb-backlinks",
   "repository": {
     "type": "git",


### PR DESCRIPTION
For issue #16. 

Note: this would be released as `0.8.0` on the npm dist-tag `alternative`, while `1.0.0` is on dist-tag `latest`. Which means the only way of getting `0.8.0` is to explicitly opt-in for it.