### PR TITLE
add indexing of cloaked messages

### DIFF
--- a/emit-links.js
+++ b/emit-links.js
@@ -3,20 +3,24 @@ var matchChannel = /^#[^\s#]+$/
 
 module.exports = emitLinks
 
+const UNKNOWN = 0
+const FEED = 1
+const MSG = 1
+const CLOAKED = 1
+const BLOB = 1
+const CHANNEL = 2
+
 // we don't need invite and address types, so don't use ref.type as those are quite slow
-function type(id) {
-  if(typeof(id) !== 'string') return ''
+function type (id) {
+  if (typeof id !== 'string') return UNKNOWN
+
   var c = id.charAt(0)
-  if (c == '@' && ref.isFeedId(id))
-    return 'feed'
-  else if (c == '%' && ref.isMsgId(id))
-    return 'msg'
-  else if (c == '&' && ref.isBlobId(id))
-    return 'blob'
-  else if (c == '#' && isChannel(id))
-    return 'channel'
-  else
-    return ''
+  if (c === '@' && ref.isFeedId(id)) return FEED
+  else if (c === '%' && ref.isMsgId(id)) return MSG
+  else if (c === '%' && ref.isCloakedMsgId(id)) return CLOAKED
+  else if (c === '&' && ref.isBlobId(id)) return BLOB
+  else if (c === '#' && isChannel(id)) return CHANNEL
+  else return UNKNOWN
 }
 
 function emitLinks (msg, emit) {
@@ -32,21 +36,24 @@ function emitLinks (msg, emit) {
 
     var idType = type(value)
 
-    if (idType == 'channel')
+    if (idType === CHANNEL)
       links.add(`#${ref.normalizeChannel(value.slice(1))}`)
-    else if (idType != '')
+    else if (idType !== UNKNOWN)
       links.add(value)
   })
+
+  const rts = resolveTimestamp(msg)
   links.forEach(link => {
-    emit(Object.assign({}, msg, {
-      rts: resolveTimestamp(msg),
-      dest: link
-    }))
+    emit(Object.assign({}, msg, { rts, dest: link }))
   })
 }
 
 function isChannel (value) {
-  return typeof value === 'string' && value.length < 30 && matchChannel.test(value)
+  return (
+    typeof value === 'string' &&
+    value.length < 30 &&
+    matchChannel.test(value)
+  )
 }
 
 function resolveTimestamp (msg) {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var indexes = [
   { key: 'TDT', value: [['value', 'content', 'type'], ['dest'], ['rts']] }
 ]
 
-var indexVersion = 10 
+var indexVersion = 11
 
 exports.name = 'backlinks'
 exports.version = require('./package.json').version

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "url": "git://github.com/ssbc/ssb-backlinks.git"
   },
   "dependencies": {
-    "base64-url": "^2.2.0",
-    "flumeview-links": "^2.0.1",
-    "pull-stream": "^3.6.7",
+    "base64-url": "^2.3.3",
+    "flumeview-links": "^2.1.0",
+    "pull-stream": "^3.6.14",
     "ssb-keys": "^7.0.14",
-    "ssb-ref": "^2.9.0"
+    "ssb-ref": "^2.14.0"
   },
   "devDependencies": {
     "ava": "^0.25.0",

--- a/test/emit-links.test.js
+++ b/test/emit-links.test.js
@@ -24,8 +24,26 @@ test('emitLinks does not call emit fn if there are no links', (t) => {
   t.true(emit.notCalled)
 })
 
-test('emitLinks calls emit fn if links are found in content', (t) => {
+test('emitLinks calls emit fn if links (feedId) are found in content', (t) => {
   const msg = { value: { content: { contact: '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519' } } }
+  emitLinks(msg, emit)
+  t.true(emit.calledOnce)
+})
+
+test('emitLinks calls emit fn if links are found in content (array)', (t) => {
+  const msg = { value: { content: { contacts: ['@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519'] } } }
+  emitLinks(msg, emit)
+  t.true(emit.calledOnce)
+})
+
+test('emitLinks calls emit fn if links (msgId) are found in content', (t) => {
+  const msg = { value: { content: { contact: '%6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.sha256' } } }
+  emitLinks(msg, emit)
+  t.true(emit.calledOnce)
+})
+
+test('emitLinks calls emit fn if links (cloakedMsgId) are found in content', (t) => {
+  const msg = { value: { content: { contact: '%6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.cloaked' } } }
   emitLinks(msg, emit)
   t.true(emit.calledOnce)
 })


### PR DESCRIPTION
with the advent of cloaked message id's (see envelope spec) we want to be able to backlinks references to cloaked messages .. this is particularly useful when the cloakedId is a groupId.

this adds tests for that, bumps the version of the index to stimulate a reindex